### PR TITLE
devops: Release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,34 @@
+on:
+  push:
+    tags:
+       - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - run: npm ci
+      - name: Run Tests
+        run: npx ng test --browsers FirefoxHeadless --watch false
+      - name: Build dist
+        run: npx ng Build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: ./dist/
+      - name: Create release on GitHub
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: false
+          artifacts: dist
+          name: "Nood ${{github.ref_name}}"
+          generateReleaseNotes: true
+          commit: "main"
+          tag: ${{github.ref_name}}
+          token: ${{ secrets.WORKFLOW_ACCESS_TOKEN }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,16 @@
+name: Build and publish Docker Image
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build image (version tag and latest tag)
+      run : docker build . -t ${{secrets.DOCKER_USERNAME}}/nood:${{ github.event.release.tag_name }} -t ${{secrets.DOCKER_USERNAME}}/nood:latest
+    - name: Login to docker
+      run: docker login -u ${{secrets.DOCKER_USERNAME}} --password ${{secrets.DOCKER_PASSWORD}}
+    - name: Push image
+      run: docker push ${{secrets.DOCKER_USERNAME}}/nood --all-tags


### PR DESCRIPTION
Workflow that creates a new release on GitHub when a tag is pushed

- The docker image is build and pushed to Docker Hub
- The dist-directory is pushed directly to GitHub (Github release is mostly for showing changelogs)

Closes https://github.com/ascendise/nood/issues/16