### PR TITLE
fix: List of other tasks should only include tasks that aren't part of checklist

### DIFF
--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -1,6 +1,6 @@
 <div class="d-flex flex-row flex-wrap justify-content-around align-items-stretch mt-5">
   <div class="col my-2 d-flex justify-content-center">
-    <app-checklist [tasks]="tasks" title="All tasks"></app-checklist>
+    <app-checklist [tasks]="tasksWithoutChecklist" title="All tasks"></app-checklist>
   </div>
   <div class="col my-2 d-flex justify-content-center" *ngFor="let checklist of checklists">
     <app-checklist [tasks]="checklist.tasks" [title]="getUniqueName(checklist)" [checklist]="checklist">

--- a/src/app/components/dashboard/dashboard.component.html
+++ b/src/app/components/dashboard/dashboard.component.html
@@ -1,10 +1,10 @@
 <div class="d-flex flex-row flex-wrap justify-content-around align-items-stretch mt-5">
-  <div class="col my-2 d-flex justify-content-center">
-    <app-checklist [tasks]="tasksWithoutChecklist" title="All tasks"></app-checklist>
-  </div>
   <div class="col my-2 d-flex justify-content-center" *ngFor="let checklist of checklists">
     <app-checklist [tasks]="checklist.tasks" [title]="getUniqueName(checklist)" [checklist]="checklist">
     </app-checklist>
+  </div>
+  <div class="col my-2 d-flex justify-content-center">
+    <app-checklist [tasks]="tasksWithoutChecklist" title="Other Tasks"></app-checklist>
   </div>
 </div>
 <div class="position-absolute bottom-0 end-0 p-5">

--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -40,13 +40,13 @@ export class DashboardComponent implements OnInit {
     return this._tasks;
   }
 
-  public get tasksWithoutChecklist() : TaskEntity[] {
-    return this.tasks.filter(t => !this.isInChecklist(t))
+  public get tasksWithoutChecklist(): TaskEntity[] {
+    return this.tasks.filter((t) => !this.isInChecklist(t));
   }
 
   private isInChecklist(task: TaskEntity) {
-    for(const c of this.checklists) {
-      if(c.tasks.includes(task)) {
+    for (const c of this.checklists) {
+      if (c.tasks.includes(task)) {
         return true;
       }
     }

--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -40,6 +40,19 @@ export class DashboardComponent implements OnInit {
     return this._tasks;
   }
 
+  public get tasksWithoutChecklist() : TaskEntity[] {
+    return this.tasks.filter(t => !this.isInChecklist(t))
+  }
+
+  private isInChecklist(task: TaskEntity) {
+    for(const c of this.checklists) {
+      if(c.tasks.includes(task)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   public get checklists(): ChecklistEntity[] {
     return this._checklists;
   }


### PR DESCRIPTION
Previously there was a list of tasks where just all are listed, no matter if they are part of a checklist or not. After some time this list could get quite large and especially hard to search.

Replaced this with a list where only the tasks without a checklist are listed. This makes the dashboard look much more organized