### PR TITLE
perf: compress files with gzip

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,5 @@
 :80
 
+encode gzip
 file_server
 try_files {path} /


### PR DESCRIPTION
Configured the caddy server inside the docker container to compress files with gzip before sending them over the wire.
Reduces the size of the sent payload