### PR TITLE
fix/access-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ services:
   todolistapi:
     depends_on:
       - mysql
-    image: "ascendise/todolistapi:2.0"
+    image: "ascendise/todolistapi:3.0"
     ports:
       - "5050:8080"
     links:
@@ -44,6 +44,7 @@ services:
       server.servlet.context-path: "/api"
       spring.output.ansi.enabled: "DETECT"
       logging.level.org.springframework.web: DEBUG
+      oauth2.audience: "{placeholder}"
   nood:
     depends_on:
       - todolistapi

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ services:
   nood:
     depends_on:
       - todolistapi
-    image: "ascendise/nood:1"
+    image: "ascendise/nood:2"
     ports:
       - "4200:80"
     environment:

--- a/src/app/components/profile/profile.component.html
+++ b/src/app/components/profile/profile.component.html
@@ -1,11 +1,11 @@
 <div class="container h-100 my-5 p-3 border rounded shadow">
-  <h1 class="text-center">Profile of {{ user.username }}</h1>
+  <h1 class="text-center">Profile of {{ identity.given_name }}</h1>
   <div class="mx-5">
     <div>
-      Your username is <span class="fw-bold">{{ user.username }}</span>
+      Your username is <span class="fw-bold">{{ identity.given_name }}</span>
     </div>
     <div>
-      Your id is <span class="fw-bold">{{ user.subject }}</span>
+      Your id is <span class="fw-bold">{{ identity.sub }}</span>
     </div>
     <button class="btn btn-danger my-2" data-bs-toggle="modal" data-bs-target="#delete-dialog">Delete Profile</button>
   </div>

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { ProfileService, User } from 'src/app/services/profile/profile.service';
+import { OAuthService } from 'angular-oauth2-oidc';
+import { ProfileService } from 'src/app/services/profile/profile.service';
 
 @Component({
   selector: 'app-profile',
@@ -8,20 +9,25 @@ import { ProfileService, User } from 'src/app/services/profile/profile.service';
   styleUrls: ['./profile.component.scss'],
 })
 export class ProfileComponent implements OnInit {
-  private _user!: User;
+  private _identity!: Identity;
 
-  constructor(private profileService: ProfileService, private router: Router) {}
+  constructor(private profileService: ProfileService, private authService: OAuthService, private router: Router) {}
 
   async ngOnInit() {
-    this._user = await this.profileService.getUser();
+    this._identity = this.authService.getIdentityClaims() as Identity;
   }
 
-  public get user() {
-    return this._user;
+  public get identity() {
+    return this._identity;
   }
 
   public async deleteProfile() {
     await this.profileService.deleteUser();
     this.router.navigateByUrl('/');
   }
+}
+
+interface Identity {
+  given_name: string,
+  sub: string,
 }

--- a/src/app/components/profile/profile.component.ts
+++ b/src/app/components/profile/profile.component.ts
@@ -28,6 +28,6 @@ export class ProfileComponent implements OnInit {
 }
 
 interface Identity {
-  given_name: string,
-  sub: string,
+  given_name: string;
+  sub: string;
 }

--- a/src/app/interceptors/authorization.interceptor.ts
+++ b/src/app/interceptors/authorization.interceptor.ts
@@ -8,7 +8,7 @@ export class AuthorizationInterceptor implements HttpInterceptor {
   constructor(private oauthService: OAuthService) {}
 
   intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
-    const idToken = this.oauthService.getIdToken();
+    const idToken = this.oauthService.getAccessToken();
     request = request.clone({
       setHeaders: { Authorization: `Bearer ${idToken}` },
     });

--- a/src/app/services/profile/profile.service.spec.ts
+++ b/src/app/services/profile/profile.service.spec.ts
@@ -47,7 +47,6 @@ describe('ProfileService', () => {
     await waitForRequest();
     const expectedUser: User = {
       subject: 'myoauth-subject12345',
-      username: 'anon123',
     };
     const request = httpTestingController.expectOne(`${API_BASE_URI}/user`);
     expect(request.request.method).toEqual('GET');

--- a/src/app/services/profile/profile.service.ts
+++ b/src/app/services/profile/profile.service.ts
@@ -25,5 +25,4 @@ export class ProfileService {
 
 export interface User {
   subject: string;
-  username: string;
 }


### PR DESCRIPTION
sends access_token instead of id_token as the API expects.

The API also no longer provides alot of user information besides the "sub"-claim. Therefore the profile-component just uses the information in the id_token